### PR TITLE
Bumping the react-bootstrap package for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "geocoder": "0.2.x",
-    "react-bootstrap": "^0.30.5",
+    "react-bootstrap": "^0.31.5",
     "react-datetime": "^2.6.0",
     "react-google-maps": "4.x.x",
     "react-select": "1.0.0-beta14",


### PR DESCRIPTION
By pumping this version it should update react-overlays to the latest version. (The old version of react-overlays uses PropTypes)